### PR TITLE
[feat] delete in bulk every 10 minutes and consolidate deletion code

### DIFF
--- a/src/events/common.ts
+++ b/src/events/common.ts
@@ -1,10 +1,13 @@
 /* eslint-disable promise/prefer-await-to-then */
 import process from 'node:process';
+import { setTimeout } from 'node:timers/promises';
 import type { Message, Client, TextChannel } from 'discord.js';
 import logger from '../logger.js';
 import type { MessageItem } from '../model/messageItem.js';
 
 export const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1_000;
+export const FIVE_MINUTES = 5 * 60 * 1_000;
+export const FIVE_SECONDS = 5 * 1_000;
 
 const expireMessage = async (message: Message) =>
 	message
@@ -34,6 +37,8 @@ export const expireMessages = async (client: Client): Promise<void> => {
 					bulkDeletable.push(message.message);
 				} else {
 					await expireMessage(message.message);
+					// if we're deleting one by one, wait so that we don't get rate limited.
+					await setTimeout(FIVE_SECONDS);
 				}
 			} else {
 				undeletedMessages.push(message);

--- a/src/events/common.ts
+++ b/src/events/common.ts
@@ -1,32 +1,55 @@
+/* eslint-disable promise/prefer-await-to-then */
 import process from 'node:process';
-import { Message, Client, TextChannel } from 'discord.js';
+import type { Message, Client, TextChannel } from 'discord.js';
 import logger from '../logger.js';
+import type { MessageItem } from '../model/messageItem.js';
 
-export const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+export const TWENTY_FOUR_HOURS = 60 * 1_000; // 24 * 60 * 60 * 1_000;
 
-export const expireMessage = (message: Message) =>
+const expireMessage = async (message: Message) =>
 	message
 		.delete()
 		.then((deletedMsg) => {
 			logger.info(`Deleted message ${deletedMsg.id} successfully.`);
 		})
-		.catch((err) => {
+		.catch((error) => {
 			logger.error(`Error expiring ${message.id}:`);
-			logger.error(err);
+			logger.error(error);
 		});
 
-		
 export const expireMessages = async (client: Client): Promise<void> => {
-	let bulkDeletable: Array<Message> = [];
-	for (const message of messageQueue) {
-		if (message.shouldDelete()) {
-			bulkDeletable.push(message.message);
+	const messageQueueSnapshot: MessageItem[] = globalThis.messageQueue.snapshot();
+	globalThis.messageQueue.clearQueue();
+	const bulkDeletable: Message[] = [];
+	const undeletedMessages: MessageItem[] = [];
+	while (messageQueueSnapshot.length !== 0) {
+		const message = messageQueueSnapshot.shift();
+		if (message === undefined) {
+			continue;
+		}
+
+		try {
+			if (await message.shouldDelete()) {
+				if (message.message.bulkDeletable) {
+					bulkDeletable.push(message.message);
+				} else {
+					await expireMessage(message.message);
+				}
+			} else {
+				undeletedMessages.push(message);
+			}
+		} catch (error: any) {
+			logger.error(error);
+			undeletedMessages.push(message);
 		}
 	}
-	
-	let channel = await client.channels.fetch(process.env.CHANNEL_ID!) as TextChannel;
-	
-	channel.bulkDelete(bulkDeletable)
+
+	const channel = (await client.channels.fetch(process.env.CHANNEL_ID!)) as TextChannel;
+
+	channel
+		.bulkDelete(bulkDeletable)
 		.then((messages) => logger.info(`Bulk deleted ${messages.size} messages.`))
-		.catch((err) => logger.error(err));
+		.catch((error) => logger.error(error));
+
+	for (const msg of undeletedMessages) global.messageQueue.addToQueue(msg);
 };

--- a/src/events/common.ts
+++ b/src/events/common.ts
@@ -4,7 +4,7 @@ import type { Message, Client, TextChannel } from 'discord.js';
 import logger from '../logger.js';
 import type { MessageItem } from '../model/messageItem.js';
 
-export const TWENTY_FOUR_HOURS = 60 * 1_000; // 24 * 60 * 60 * 1_000;
+export const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1_000;
 
 const expireMessage = async (message: Message) =>
 	message

--- a/src/events/common.ts
+++ b/src/events/common.ts
@@ -6,7 +6,7 @@ import logger from '../logger.js';
 import type { MessageItem } from '../model/messageItem.js';
 
 export const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1_000;
-export const FIVE_MINUTES = 5 * 60 * 1_000;
+export const TEN_MINUTES = 10 * 60 * 1_000;
 export const FIVE_SECONDS = 5 * 1_000;
 
 const expireMessage = async (message: Message) =>
@@ -62,6 +62,7 @@ export const expireMessages = async (client: Client): Promise<void> => {
 			.bulkDelete(toDelete)
 			.then((messages) => logger.info(`Bulk deleted ${messages.size} messages.`))
 			.catch((error) => logger.error(error));
+		await setTimeout(FIVE_SECONDS);
 	}
 
 	for (const msg of undeletedMessages) global.messageQueue.addToQueue(msg);

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -2,9 +2,9 @@ import process from 'node:process';
 import type { Message } from 'discord.js';
 import { Events } from 'discord.js';
 import logger from '../logger.js';
+import { MessageItem } from '../model/messageItem.js';
 import { TWENTY_FOUR_HOURS } from './common.js';
 import type { Event } from './index.js';
-import { MessageItem } from '../model/messageItem.js';
 
 export default {
 	name: Events.MessageCreate,
@@ -16,6 +16,6 @@ export default {
 		}
 
 		logger.info(`Message received: ${message.id}`);
-		messageQueue.push(new MessageItem(message, TWENTY_FOUR_HOURS));
+		globalThis.messageQueue.addToQueue(new MessageItem(message, TWENTY_FOUR_HOURS));
 	},
 } satisfies Event<Events.MessageCreate>;

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -2,8 +2,9 @@ import process from 'node:process';
 import type { Message } from 'discord.js';
 import { Events } from 'discord.js';
 import logger from '../logger.js';
-import { expireMessageAfter, TWENTY_FOUR_HOURS } from './common.js';
+import { TWENTY_FOUR_HOURS } from './common.js';
 import type { Event } from './index.js';
+import { MessageItem } from '../model/messageItem.js';
 
 export default {
 	name: Events.MessageCreate,
@@ -15,6 +16,6 @@ export default {
 		}
 
 		logger.info(`Message received: ${message.id}`);
-		await expireMessageAfter(message, TWENTY_FOUR_HOURS);
+		messageQueue.push(new MessageItem(message, TWENTY_FOUR_HOURS));
 	},
 } satisfies Event<Events.MessageCreate>;

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,11 +1,11 @@
 import process from 'node:process';
+import { setInterval } from 'node:timers';
 import type { Client, Message, TextChannel, Collection } from 'discord.js';
 import { Events } from 'discord.js';
-import type { Event } from './index.js';
-import { TWENTY_FOUR_HOURS } from './common.js';
-import { expireMessageAfter } from './common.js';
 import logger from '../logger.js';
 import { MessageItem } from '../model/messageItem.js';
+import { TWENTY_FOUR_HOURS, expireMessages } from './common.js';
+import type { Event } from './index.js';
 
 export default {
 	name: Events.ClientReady,
@@ -15,8 +15,6 @@ export default {
 		if (channel === null) {
 			return;
 		}
-
-		const bulkDeletable: Message<boolean>[] = [];
 
 		// Discord doesn't let us fetch all of the messages at once: it paginates it.
 		// Since Discord.js doesn't handle that pagination natively, we have to build
@@ -33,55 +31,42 @@ export default {
 
 		// To avoid rate limiting, we artificially insert a 5 second delay between
 		// deletions.
-		const delayIfExpired = 5000;
+		const delayIfExpired = 5_000;
 
 		let currentMsgPointer: Message<boolean> | null | undefined = latestMessage;
 		while (currentMsgPointer) {
 			// Get the 100 messages before the pointer
-			let messagePage: Collection<string, Message<true>> = await channel.messages.fetch({
+			const messagePage: Collection<string, Message<true>> = await channel.messages.fetch({
 				limit: 100,
 				before: currentMsgPointer.id,
 			});
 
 			// Check each to see if they're expired.
 			for (const message of messagePage.values()) {
-				const expectedExpireTimestamp = message.createdTimestamp + TWENTY_FOUR_HOURS;
 				const now = Date.now();
-				if (message.pinned) {
-					continue;
-				} else if (message.bulkDeletable) {
-					// Prefer to minimize calls to the Discord API to avoid
-					// rate limiting. Instead, call bulk delete once with
-					// eligible messages.
-
-					// Only delete expirable messages, though!
-					if (expectedExpireTimestamp <= now) {
-						bulkDeletable.push(message);
-					}
-
-					continue;
-				}
 
 				let timeout = delayIfExpired;
 
 				// If we've found a message that should expire in the future, create an expiration for it.
-				if (expectedExpireTimestamp > now) {
-					timeout = expectedExpireTimestamp - now;
+				if (message.createdTimestamp + TWENTY_FOUR_HOURS > now) {
+					timeout = TWENTY_FOUR_HOURS;
 				}
 
-				messageQueue.push(new MessageItem(message, timeout));
+				logger.info(`Message queued: ${message.id}`);
+				globalThis.messageQueue.addToQueue(new MessageItem(message, timeout, message.createdAt));
 			}
 
 			// Update our message pointer to be the last message on the page of messages
-			currentMsgPointer = 0 < messagePage.size ? messagePage.at(messagePage.size - 1) : null;
+			currentMsgPointer = messagePage.size > 0 ? messagePage.at(messagePage.size - 1) : null;
 		}
 
-		await channel
-			.bulkDelete(bulkDeletable)
-			.then((messages) => logger.info(`Bulk deleted ${messages.size} messages.`))
-			.catch((err) => logger.error(err));
+		logger.info(`Message queued: ${latestMessage.id}`);
+		globalThis.messageQueue.addToQueue(new MessageItem(latestMessage, TWENTY_FOUR_HOURS, latestMessage.createdAt));
 
-		const scheduledExpiration = Date.now() - (latestMessage.createdTimestamp + TWENTY_FOUR_HOURS);
-		messageQueue.push(new MessageItem(latestMessage, Math.max(scheduledExpiration, 0)));
+		await expireMessages(client);
+
+		setInterval(async () => {
+			await expireMessages(client);
+		}, 10 * 1_000);
 	},
 } satisfies Event<Events.ClientReady>;

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -5,6 +5,7 @@ import type { Event } from './index.js';
 import { TWENTY_FOUR_HOURS } from './common.js';
 import { expireMessageAfter } from './common.js';
 import logger from '../logger.js';
+import { MessageItem } from '../model/messageItem.js';
 
 export default {
 	name: Events.ClientReady,
@@ -68,7 +69,7 @@ export default {
 					timeout = expectedExpireTimestamp - now;
 				}
 
-				await expireMessageAfter(message, timeout);
+				messageQueue.push(new MessageItem(message, timeout));
 			}
 
 			// Update our message pointer to be the last message on the page of messages
@@ -81,6 +82,6 @@ export default {
 			.catch((err) => logger.error(err));
 
 		const scheduledExpiration = Date.now() - (latestMessage.createdTimestamp + TWENTY_FOUR_HOURS);
-		expireMessageAfter(latestMessage, Math.max(scheduledExpiration, 0));
+		messageQueue.push(new MessageItem(latestMessage, Math.max(scheduledExpiration, 0)));
 	},
 } satisfies Event<Events.ClientReady>;

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -4,7 +4,7 @@ import type { Client, Message, TextChannel, Collection } from 'discord.js';
 import { Events } from 'discord.js';
 import logger from '../logger.js';
 import { MessageItem } from '../model/messageItem.js';
-import { FIVE_MINUTES, TWENTY_FOUR_HOURS, expireMessages } from './common.js';
+import { TEN_MINUTES, TWENTY_FOUR_HOURS, expireMessages } from './common.js';
 import type { Event } from './index.js';
 
 export default {
@@ -57,6 +57,6 @@ export default {
 		// set the loop up.
 		setInterval(async () => {
 			await expireMessages(client);
-		}, FIVE_MINUTES);
+		}, TEN_MINUTES);
 	},
 } satisfies Event<Events.ClientReady>;

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,0 +1,6 @@
+import type { MessageQueue } from './model/messageQueue.js';
+
+declare global {
+	// eslint-disable-next-line vars-on-top, no-var
+	var messageQueue: MessageQueue;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,15 @@
 import process from 'node:process';
 import { URL } from 'node:url';
 import { Client, GatewayIntentBits } from 'discord.js';
+import { MessageItem } from './model/messageItem.js';
 import { loadCommands, loadEvents } from './util/loaders.js';
 import { registerEvents } from './util/registerEvents.js';
+import { set } from 'zod';
+import { expireMessages } from './events/common.js';
+
+declare global {
+    let messageQueue: Array<MessageItem>;
+}
 
 // Initialize the client
 const client = new Client({ intents: [GatewayIntentBits.GuildMessages, GatewayIntentBits.Guilds] });
@@ -13,6 +20,14 @@ const commands = await loadCommands(new URL('commands/', import.meta.url));
 
 // Register the event handlers
 registerEvents(commands, events, client);
+
+messageQueue = new Array<MessageItem>();
+
+client.once('ready', async (client : Client) => {
+    setInterval(() => {
+        expireMessages(client);
+    }, 1000);
+});
 
 // Login to the client
 void client.login(process.env.DISCORD_TOKEN);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,11 @@
 import process from 'node:process';
 import { URL } from 'node:url';
 import { Client, GatewayIntentBits } from 'discord.js';
-import { MessageItem } from './model/messageItem.js';
+import { MessageQueue } from './model/messageQueue.js';
 import { loadCommands, loadEvents } from './util/loaders.js';
 import { registerEvents } from './util/registerEvents.js';
-import { set } from 'zod';
-import { expireMessages } from './events/common.js';
 
-declare global {
-    let messageQueue: Array<MessageItem>;
-}
+import './globals.js';
 
 // Initialize the client
 const client = new Client({ intents: [GatewayIntentBits.GuildMessages, GatewayIntentBits.Guilds] });
@@ -21,13 +17,7 @@ const commands = await loadCommands(new URL('commands/', import.meta.url));
 // Register the event handlers
 registerEvents(commands, events, client);
 
-messageQueue = new Array<MessageItem>();
-
-client.once('ready', async (client : Client) => {
-    setInterval(() => {
-        expireMessages(client);
-    }, 1000);
-});
+globalThis.messageQueue = new MessageQueue();
 
 // Login to the client
 void client.login(process.env.DISCORD_TOKEN);

--- a/src/model/messageItem.ts
+++ b/src/model/messageItem.ts
@@ -1,20 +1,26 @@
-import { Message } from 'discord.js';
+import type { Message } from 'discord.js';
 
 export class MessageItem {
-    message: Message;
-    timestamp: Date;
-    deleteAfterMs: number;
+	public messageId: string;
 
-    constructor(message: Message, deleteAfterMs: number) {
-        this.message = message;
-        this.timestamp = new Date();
-        this.deleteAfterMs = deleteAfterMs;
-    }
+	public message: Message;
 
-    shouldDelete(): boolean {
-        const now = new Date().getTime();
-        const timeAdded = this.timestamp.getTime();
-        const refreshedMessage = this.message.fetch(true);
-        return (now - timeAdded >= this.deleteAfterMs) && !refreshedMessage.pinned;
-    }
+	public timestamp: Date;
+
+	public deleteAfterMs: number;
+
+	public constructor(message: Message, deleteAfterMs: number, timestamp: Date | null = null) {
+		this.messageId = message.id;
+		this.message = message;
+		this.timestamp = timestamp ?? new Date();
+		this.deleteAfterMs = deleteAfterMs;
+	}
+
+	public async shouldDelete(): Promise<boolean> {
+		const now = Date.now();
+		const timeAdded = this.timestamp.getTime();
+		const refreshedMessage = await this.message.fetch(true);
+		this.message = refreshedMessage;
+		return now - timeAdded >= this.deleteAfterMs && !this.message.pinned;
+	}
 }

--- a/src/model/messageItem.ts
+++ b/src/model/messageItem.ts
@@ -1,0 +1,20 @@
+import { Message } from 'discord.js';
+
+export class MessageItem {
+    message: Message;
+    timestamp: Date;
+    deleteAfterMs: number;
+
+    constructor(message: Message, deleteAfterMs: number) {
+        this.message = message;
+        this.timestamp = new Date();
+        this.deleteAfterMs = deleteAfterMs;
+    }
+
+    shouldDelete(): boolean {
+        const now = new Date().getTime();
+        const timeAdded = this.timestamp.getTime();
+        const refreshedMessage = this.message.fetch(true);
+        return (now - timeAdded >= this.deleteAfterMs) && !refreshedMessage.pinned;
+    }
+}

--- a/src/model/messageQueue.ts
+++ b/src/model/messageQueue.ts
@@ -1,0 +1,23 @@
+import type { MessageItem } from './messageItem.js';
+
+export class MessageQueue {
+	public _queue: MessageItem[];
+
+	public constructor() {
+		this._queue = new Array<MessageItem>();
+	}
+
+	public addToQueue(messageToAdd: MessageItem): void {
+		if (!this._queue.some((msg) => msg.messageId === messageToAdd.messageId)) {
+			this._queue.push(messageToAdd);
+		}
+	}
+
+	public snapshot(): MessageItem[] {
+		return this._queue.slice();
+	}
+
+	public clearQueue(): void {
+		this._queue = [];
+	}
+}


### PR DESCRIPTION
# Overview

- Creates `MessageQueue` and `MessageItem` constructs for handling data.
- Creates unified logic for deleting expired messages.
- Creates a global message queue that has its queue checked every 10 minutes.
- Makes sure to bulk delete only 100 at a time.

Tested and verified on my personal server.